### PR TITLE
Normalize to unix style paths before filtering out "internals".

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,8 +38,8 @@ StackUtils.prototype.clean = function (stack) {
 	var lastNonAtLine = null;
 	var result = [];
 
-	stack.forEach(function (st1) {
-		var st = st1;
+	stack.forEach(function (st) {
+		st = st.replace(/\\/g, '/');
 		var isInternal = this._internals.some(function (internal) {
 			return internal.test(st);
 		});
@@ -59,9 +59,7 @@ StackUtils.prototype.clean = function (stack) {
 			}
 		}
 
-		st = st
-			.replace(/\\/g, '/')
-			.replace(this._cwd + '/', '');
+		st = st.replace(this._cwd + '/', '');
 
 		if (st) {
 			if (isAtLine) {

--- a/test/long-stack-traces.js
+++ b/test/long-stack-traces.js
@@ -8,13 +8,13 @@ import {join, fixtureDir} from './_utils';
 
 function internals() {
 	return StackUtils.nodeInternals().concat([
-		/[\\\/]long-stack-traces\.js:[0-9]+:[0-9]+\)?$/,
-		/[\\\/]internal-error\.js:[0-9]+:[0-9]+\)?$/,
-		/[\\\/]internal-then\.js:[0-9]+:[0-9]+\)?$/,
-		/[\\\/]node_modules[\\\/]/,
+		/\/long-stack-traces\.js:[0-9]+:[0-9]+\)?$/,
+		/\/internal-error\.js:[0-9]+:[0-9]+\)?$/,
+		/\/internal-then\.js:[0-9]+:[0-9]+\)?$/,
+		/\/node_modules\//,
 		// TODO: Should any of these be default internals?
-		/[\\\/]\.node-spawn-wrap-\w+-\w+[\\\/]node:[0-9]+:[0-9]+\)?$/,
-		/internal[\\\/]module\.js:[0-9]+:[0-9]+\)?$/,
+		/\/\.node-spawn-wrap-\w+-\w+\/node:[0-9]+:[0-9]+\)?$/,
+		/internal\/module\.js:[0-9]+:[0-9]+\)?$/,
 		/node\.js:[0-9]+:[0-9]+\)?$/
 	]);
 }

--- a/test/test.js
+++ b/test/test.js
@@ -327,6 +327,6 @@ function internalStack() {
 function internals() {
 	return StackUtils.nodeInternals().concat([
 		/test\.js:[0-9]+:[0-9]+\)?$/,
-		/[\\\/]node_modules[\\\/]/
+		/\/node_modules\//
 	]);
 }


### PR DESCRIPTION
This makes it a little easier to write regular expressions for internals by normalizing the array before applying the filter. This means your regular expression only needs to deal with forward slash separators

Fixes #9