### PR TITLE
Add a more complete list of Nodes internal files to `nodeInternals()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,15 +12,16 @@ function StackUtils(opts) {
 module.exports.nodeInternals = nodeInternals;
 
 function nodeInternals() {
-	// This was tap specific
-	// /node_modules[\\\/]tap[\\\/](.*?)\.js:[0-9]:[0-9]\)?$/
 	return [
-		/\(domain.js:[0-9]+:[0-9]+\)$/,
-		/\(events.js:[0-9]+:[0-9]+\)$/,
-		/\(node.js:[0-9]+:[0-9]+\)$/,
-		/\(timers.js:[0-9]+:[0-9]+\)$/,
-		/\(module.js:[0-9]+:[0-9]+\)$/,
-		/GeneratorFunctionPrototype.next \(native\)/
+		/\(native\)$/,
+		/\(domain.js:\d+:\d+\)$/,
+		/\(events.js:\d+:\d+\)$/,
+		/\(node.js:\d+:\d+\)$/,
+		/\(timers.js:\d+:\d+\)$/,
+		/\(module.js:\d+:\d+\)$/,
+		/\(internal\/[\w_-]+\.js:\d+:\d+\)$/,
+		/\s*at node\.js:\d+:\d+?$/,
+		/\/\.node-spawn-wrap-\w+-\w+\/node:\d+:\d+\)?$/
 	];
 }
 
@@ -211,11 +212,11 @@ var re = new RegExp(
 		// (eval at <anonymous> (file.js:1:1),
 		// $4 = eval origin
 		// $5:$6:$7 are eval file/line/col, but not normally reported
-	'(?:eval at ([^ ]+) \\(([^\\)]+):([0-9]+):([0-9]+)\\), )?' +
+	'(?:eval at ([^ ]+) \\(([^\\)]+):(\\d+):(\\d+)\\), )?' +
 		// file:line:col
 		// $8:$9:$10
 		// $11 = 'native' if native
-	'(?:([^\\)]+):([0-9]+):([0-9]+)|(native))' +
+	'(?:([^\\)]+):(\\d+):(\\d+)|(native))' +
 		// maybe close the paren, then end
 	'\\)?$'
 );

--- a/test/long-stack-traces.js
+++ b/test/long-stack-traces.js
@@ -8,14 +8,10 @@ import {join, fixtureDir} from './_utils';
 
 function internals() {
 	return StackUtils.nodeInternals().concat([
-		/\/long-stack-traces\.js:[0-9]+:[0-9]+\)?$/,
-		/\/internal-error\.js:[0-9]+:[0-9]+\)?$/,
-		/\/internal-then\.js:[0-9]+:[0-9]+\)?$/,
-		/\/node_modules\//,
-		// TODO: Should any of these be default internals?
-		/\/\.node-spawn-wrap-\w+-\w+\/node:[0-9]+:[0-9]+\)?$/,
-		/internal\/module\.js:[0-9]+:[0-9]+\)?$/,
-		/node\.js:[0-9]+:[0-9]+\)?$/
+		/\/long-stack-traces\.js:\d+:\d+\)?$/,
+		/\/internal-error\.js:\d+:\d+\)?$/,
+		/\/internal-then\.js:\d+:\d+\)?$/,
+		/\/node_modules\//
 	]);
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -326,7 +326,7 @@ function internalStack() {
 
 function internals() {
 	return StackUtils.nodeInternals().concat([
-		/test\.js:[0-9]+:[0-9]+\)?$/,
+		/test\.js:\d+:\d+\)?$/,
 		/\/node_modules\//
 	]);
 }


### PR DESCRIPTION
Also swaps `[0-9]` for `\d` everywhere.

Fixes #8.