### PR TITLE
return empty string instead of null if all internals

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ StackUtils.prototype.clean = function (stack) {
 	if (stack) {
 		return stack + '\n';
 	}
-	return null;
+	return '';
 };
 
 StackUtils.prototype.captureString = function (limit, fn) {

--- a/test/test.js
+++ b/test/test.js
@@ -56,7 +56,7 @@ test('clean: eliminates internals', t => {
 
 test('clean: returns null if it is all internals', t => {
 	const stack = new StackUtils({internals: StackUtils.nodeInternals()});
-	t.is(stack.clean(join(internalStack())), null);
+	t.is(stack.clean(join(internalStack())), '');
 });
 
 test('captureString: two redirects', t => {


### PR DESCRIPTION
PR based upon discussion at https://github.com/sindresorhus/ava/pull/510

I tested this change against [node-tap](https://github.com/tapjs/node-tap) and all test succeed except for the [coverage-checks.js](https://github.com/tapjs/node-tap/blob/master/test/coverage-checks.js) file.

```
test/coverage-checks.js ............................. 17/23 12s
```

I'm not familiar with `node-tap` at all so maybe other people can join the discussion for this tiny change. For example, why does it return `null` in the first place?

// @sindresorhus @jamestalmage @isaacs 