### PR TITLE
Added support for wrapping CallSite

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ function StackUtils(opts) {
 	opts = opts || {};
 	this._cwd = (opts.cwd || process.cwd()).replace(/\\/g, '/');
 	this._internals = opts.internals || [];
+	this._wrapCallSite = opts.wrapCallSite || false;
 }
 
 module.exports.nodeInternals = nodeInternals;
@@ -117,8 +118,14 @@ StackUtils.prototype.capture = function (limit, fn) {
 	}
 	var prepBefore = Error.prepareStackTrace;
 	var limitBefore = Error.stackTraceLimit;
+	var wrapCallSite = this._wrapCallSite;
 
 	Error.prepareStackTrace = function (obj, site) {
+		if (typeof wrapCallSite === 'function') {
+			return site.map(function (callSite) {
+				return wrapCallSite(callSite);
+			});
+		}
 		return site;
 	};
 

--- a/index.js
+++ b/index.js
@@ -121,10 +121,8 @@ StackUtils.prototype.capture = function (limit, fn) {
 	var wrapCallSite = this._wrapCallSite;
 
 	Error.prepareStackTrace = function (obj, site) {
-		if (typeof wrapCallSite === 'function') {
-			return site.map(function (callSite) {
-				return wrapCallSite(callSite);
-			});
+		if (wrapCallSite) {
+			return site.map(wrapCallSite);
 		}
 		return site;
 	};

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,12 @@ Type: `string`
 
 The path to the current working directory. File names in the stack trace will be shown relative to this directory.
 
+##### wrapCallSite
+
+Type: `function(CallSite)`
+
+A function that will wrap the CallSite processed by the `StackUtils.capture()` function. The CallSite gets passed as a parameter to this function, and the function should return a new object wrapping the CallSite. Providing a CallSite wrapper enables the use of StackUtils with a source mapping module.
+
 
 ### StackUtils.nodeInternals()
 

--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ The path to the current working directory. File names in the stack trace will be
 
 Type: `function(CallSite)`
 
-A function that will wrap the CallSite processed by the `StackUtils.capture()` function. The CallSite gets passed as a parameter to this function, and the function should return a new object wrapping the CallSite. Providing a CallSite wrapper enables the use of StackUtils with a source mapping module.
+A mapping function for manipulating CallSites before processing. The first argument is a CallSite instance, and the function should return a modified CallSite. This is useful for providing source map support.
 
 
 ### StackUtils.nodeInternals()

--- a/test/test.js
+++ b/test/test.js
@@ -136,23 +136,22 @@ test('capture: with limit and stackStart function', t => {
 });
 
 test('capture: with wrapCallSite function', t => {
-	var wrapper = function (frame) {
-		var object = {};
-		Object.getOwnPropertyNames(Object.getPrototypeOf(frame)).forEach(function (name) {
-			object[name] = /^(?:is|get)/.test(name) ? function () {
-				return frame[name];
-			} : frame[name];
-		});
-		object.getFunctionName = function () {
-			return 'testFunctionName';
+	const wrapper = function (callsite) {
+		return {
+			getMethodName: function () {
+				return callsite.getMethodName();
+			},
+			getFunctionName: function () {
+				return 'testOverrideFunctionName';
+			}
 		};
-		return object;
 	};
 	const stackUtil = new StackUtils({internals: internals(), cwd: fixtureDir, wrapCallSite: wrapper});
 	const capture = new CaptureFixture(stackUtil);
 	const stack = capture.redirect1('redirect2', 'call', 'capture', 1, capture.call);
 	t.is(stack.length, 1);
-	t.is(stack[0].getFunctionName(), 'testFunctionName');
+	t.is(stack[0].getFunctionName(), 'testOverrideFunctionName');
+	t.is(stack[0].getMethodName(), 'redirect2');
 });
 
 test('at', t => {

--- a/test/test.js
+++ b/test/test.js
@@ -135,6 +135,26 @@ test('capture: with limit and stackStart function', t => {
 	t.is(stack[0].getFunctionName(), 'CaptureFixture.redirect2');
 });
 
+test('capture: with wrapCallSite function', t => {
+	var wrapper = function (frame) {
+		var object = {};
+		Object.getOwnPropertyNames(Object.getPrototypeOf(frame)).forEach(function (name) {
+			object[name] = /^(?:is|get)/.test(name) ? function () {
+				return frame[name];
+			} : frame[name];
+		});
+		object.getFunctionName = function () {
+			return 'testFunctionName';
+		};
+		return object;
+	};
+	const stackUtil = new StackUtils({internals: internals(), cwd: fixtureDir, wrapCallSite: wrapper});
+	const capture = new CaptureFixture(stackUtil);
+	const stack = capture.redirect1('redirect2', 'call', 'capture', 1, capture.call);
+	t.is(stack.length, 1);
+	t.is(stack[0].getFunctionName(), 'testFunctionName');
+});
+
 test('at', t => {
 	const stackUtil = new StackUtils({internals: internals(), cwd: fixtureDir});
 	const capture = new CaptureFixture(stackUtil);


### PR DESCRIPTION
This makes stack-utils compatible with modules that implement source map support making tapjs/node-tap#329 possible
