### PR TITLE
Alter parseLine regex to allow `(` character within location.

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,11 +212,11 @@ var re = new RegExp(
 		// (eval at <anonymous> (file.js:1:1),
 		// $4 = eval origin
 		// $5:$6:$7 are eval file/line/col, but not normally reported
-	'(?:eval at ([^ ]+) \\(([^\\)]+):(\\d+):(\\d+)\\), )?' +
+	'(?:eval at ([^ ]+) \\((.+):(\\d+):(\\d+)\\), )?' +
 		// file:line:col
 		// $8:$9:$10
 		// $11 = 'native' if native
-	'(?:([^\\)]+):(\\d+):(\\d+)|(native))' +
+	'(?:(.+):(\\d+):(\\d+)|(native))' +
 		// maybe close the paren, then end
 	'\\)?$'
 );


### PR DESCRIPTION
PR to open discussion regarding #23, Fail to parseLine when path contains '('.

**Example:**

```js
stackUtils.parseLine('    at Context.<anonymous> (/Users/USER/Dropbox (Personal)/example/test.js:14:11)')
// => null

stackUtils.parseLine('    at Context.<anonymous> (/Users/USER/Dropbox/example/test.js:14:11)')
// => { line: 14, column: 11, file: '/Users/USER/Dropbox/example/test.js', function: 'Context.<anonymous>' }
```

---

This may be a naive approach, but simply changing the matching pattern for location to not negate `)` appears to fix the issue while not breaking any of the existing tests. However, negating the character in the first place appears to have been a very intentional choice. I am assuming there is a missing testcase for this requirement?
