### PR TITLE
Require Node.js 4, cleanup, support symbol functions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 root = true
 
 [*]
-indent_style = tab
+indent_style = space
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - '7'
+  - '6'
+  - '4'
+after_script:
+  - 'cat ./coverage/lcov.info | ./node_modules/.bin/coveralls'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+environment:
+  matrix:
+    - nodejs_version: '7'
+    - nodejs_version: '6'
+    - nodejs_version: '4'
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - set CI=true
+  - npm -g install npm@latest || (timeout 30 && npm -g install npm@latest)
+  - set PATH=%APPDATA%\npm;%PATH%
+  - npm install || (timeout 30 && npm install)
+matrix:
+  fast_finish: true
+build: off
+version: '{build}'
+shallow_clone: true
+clone_depth: 1
+test_script:
+  - node --version
+  - npm --version
+  - npm test

--- a/index.js
+++ b/index.js
@@ -214,13 +214,16 @@ const re = new RegExp(
     // $2 = function name
     // $3 = method name
   '(?:([^\\(\\[]*)(?: \\[as ([^\\]]+)\\])? \\()?' +
+    // Object.[Symbol.…] (, maybe
+    // $4 = function name
+  '(?:([^\\(\\[]+\\[Symbol\\..+?\\]) \\()?' +
     // (eval at <anonymous> (file.js:1:1),
-    // $4 = eval origin
-    // $5:$6:$7 are eval file/line/col, but not normally reported
+    // $5 = eval origin
+    // $6:$7:$8 are eval file/line/col, but not normally reported
   '(?:eval at ([^ ]+) \\((.+?):(\\d+):(\\d+)\\), )?' +
     // file:line:col
-    // $8:$9:$10
-    // $11 = 'native' if native
+    // $9:$10:$11
+    // $12 = 'native' if native
   '(?:(.+?):(\\d+):(\\d+)|(native))' +
     // maybe close the paren, then end
   '\\)?$'
@@ -235,14 +238,15 @@ StackUtils.prototype.parseLine = function parseLine (line) {
   const ctor = match[1] === 'new'
   const fname = match[2]
   const meth = match[3]
-  const evalOrigin = match[4]
-  const evalFile = match[5]
-  const evalLine = Number(match[6])
-  const evalCol = Number(match[7])
-  const file = match[8]
-  const lnum = match[9]
-  const col = match[10]
-  const native = match[11] === 'native'
+  const symbolFname = match[4]
+  const evalOrigin = match[5]
+  const evalFile = match[6]
+  const evalLine = Number(match[7])
+  const evalCol = Number(match[8])
+  const file = match[9]
+  const lnum = match[10]
+  const col = match[11]
+  const native = match[12] === 'native'
 
   const res = {}
 
@@ -277,6 +281,10 @@ StackUtils.prototype.parseLine = function parseLine (line) {
 
   if (meth && fname !== meth) {
     res.method = meth
+  }
+
+  if (symbolFname) {
+    res.function = symbolFname
   }
 
   return res

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "node": ">=4"
   },
   "scripts": {
-    "test": "tap test/*.js --cov"
+    "test": "tap test/*.js --cov",
+    "posttest": "standard"
   },
   "files": [
     "index.js"
@@ -29,6 +30,7 @@
     "nested-error-stacks": "^2.0.0",
     "pify": "^2.3.0",
     "q": "^1.4.1",
+    "standard": "^8.6.0",
     "tap": "^10.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "github.com/jamestalmage"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4"
   },
   "scripts": {
     "test": "tap test/*.js --cov"

--- a/test/_utils.js
+++ b/test/_utils.js
@@ -1,11 +1,13 @@
-var flatten = require('flatten');
-var path = require('path');
+'use strict';
+
+const flatten = require('flatten');
+const path = require('path');
 
 module.exports.join = join;
 module.exports.fixtureDir = path.join(__dirname, 'fixtures');
 
 function join() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   return flatten(args).join('\n') + '\n';
 }
 

--- a/test/_utils.js
+++ b/test/_utils.js
@@ -1,15 +1,16 @@
-'use strict';
+'use strict'
 
-const flatten = require('flatten');
-const path = require('path');
+const flatten = require('flatten')
+const path = require('path')
 
-module.exports.join = join;
-module.exports.fixtureDir = path.join(__dirname, 'fixtures');
+module.exports.join = join
+module.exports.fixtureDir = path.join(__dirname, 'fixtures')
 
-function join() {
-  const args = Array.prototype.slice.call(arguments);
-  return flatten(args).join('\n') + '\n';
+function join () {
+  const args = Array.prototype.slice.call(arguments)
+  return flatten(args).join('\n') + '\n'
 }
 
-if (module === require.main)
+if (module === require.main) {
   require('tap').pass('this is fine')
+}

--- a/test/fixtures/capture-fixture.js
+++ b/test/fixtures/capture-fixture.js
@@ -6,27 +6,27 @@ function CaptureFixture(stack) {
 }
 
 CaptureFixture.prototype.redirect1 = function () {
-	var args = Array.prototype.slice.call(arguments);
-	var method = args.shift();
+	const args = Array.prototype.slice.call(arguments);
+	const method = args.shift();
 	return this[method].apply(this, args);
 };
 
 CaptureFixture.prototype.redirect2 = function () {
-	var args = Array.prototype.slice.call(arguments);
-	var method = args.shift();
+	const args = Array.prototype.slice.call(arguments);
+	const method = args.shift();
 	return this[method].apply(this, args);
 };
 
 CaptureFixture.prototype.call = function () {
-	var args = Array.prototype.slice.call(arguments);
-	var method = args.shift();
+	const args = Array.prototype.slice.call(arguments);
+	const method = args.shift();
 	return this.stack[method].apply(this.stack, args);
 };
 
 CaptureFixture.prototype.const = function () {
-	var args = Array.prototype.slice.call(arguments);
-	var method = args.shift();
-	var self = this;
+	const args = Array.prototype.slice.call(arguments);
+	const method = args.shift();
+	const self = this;
 
 	function Constructor() {
 		this.val = self[method].apply(self, args);
@@ -36,12 +36,12 @@ CaptureFixture.prototype.const = function () {
 };
 
 CaptureFixture.prototype.obj = function () {
-	var args = Array.prototype.slice.call(arguments);
-	var methodName = args.shift();
-	var method = args.shift();
-	var self = this;
+	const args = Array.prototype.slice.call(arguments);
+	const methodName = args.shift();
+	const method = args.shift();
+	const self = this;
 
-	var obj = {};
+	const obj = {};
 	obj[methodName] = function () {
 		return self[method].apply(self, args);
 	};
@@ -50,9 +50,9 @@ CaptureFixture.prototype.obj = function () {
 };
 
 CaptureFixture.prototype.eval = function () {
-	var args = Array.prototype.slice.call(arguments);
-	var method = args.shift();
-	var self = this;
+	const args = Array.prototype.slice.call(arguments);
+	const method = args.shift();
+	const self = this;
 
 	return eval('self[method].apply(self, args)');
 };

--- a/test/fixtures/capture-fixture.js
+++ b/test/fixtures/capture-fixture.js
@@ -1,62 +1,62 @@
-'use strict';
-module.exports = CaptureFixture;
+'use strict'
+module.exports = CaptureFixture
 
-function CaptureFixture(stack) {
-	this.stack = stack;
+function CaptureFixture (stack) {
+  this.stack = stack
 }
 
 CaptureFixture.prototype.redirect1 = function () {
-	const args = Array.prototype.slice.call(arguments);
-	const method = args.shift();
-	return this[method].apply(this, args);
-};
+  const args = Array.prototype.slice.call(arguments)
+  const method = args.shift()
+  return this[method].apply(this, args)
+}
 
 CaptureFixture.prototype.redirect2 = function () {
-	const args = Array.prototype.slice.call(arguments);
-	const method = args.shift();
-	return this[method].apply(this, args);
-};
+  const args = Array.prototype.slice.call(arguments)
+  const method = args.shift()
+  return this[method].apply(this, args)
+}
 
 CaptureFixture.prototype.call = function () {
-	const args = Array.prototype.slice.call(arguments);
-	const method = args.shift();
-	return this.stack[method].apply(this.stack, args);
-};
+  const args = Array.prototype.slice.call(arguments)
+  const method = args.shift()
+  return this.stack[method].apply(this.stack, args)
+}
 
 CaptureFixture.prototype.const = function () {
-	const args = Array.prototype.slice.call(arguments);
-	const method = args.shift();
-	const self = this;
+  const args = Array.prototype.slice.call(arguments)
+  const method = args.shift()
+  const self = this
 
-	function Constructor() {
-		this.val = self[method].apply(self, args);
-	}
+  function Constructor () {
+    this.val = self[method].apply(self, args)
+  }
 
-	return new Constructor().val;
-};
+  return new Constructor().val
+}
 
 CaptureFixture.prototype.obj = function () {
-	const args = Array.prototype.slice.call(arguments);
-	const methodName = args.shift();
-	const method = args.shift();
-	const self = this;
+  const args = Array.prototype.slice.call(arguments)
+  const methodName = args.shift()
+  const method = args.shift()
+  const self = this
 
-	const obj = {};
-	obj[methodName] = function () {
-		return self[method].apply(self, args);
-	};
+  const obj = {}
+  obj[methodName] = function () {
+    return self[method].apply(self, args)
+  }
 
-	return obj[methodName]();
-};
+  return obj[methodName]()
+}
 
 CaptureFixture.prototype.eval = function () {
-	const args = Array.prototype.slice.call(arguments);
-	const method = args.shift();
-	const self = this;
+  const args = Array.prototype.slice.call(arguments)
+  const method = args.shift() // eslint-disable-line no-unused-vars
+  const self = this // eslint-disable-line no-unused-vars
 
-	return eval('self[method].apply(self, args)');
-};
+  return eval('self[method].apply(self, args)') // eslint-disable-line no-eval
+}
 
 CaptureFixture.prototype.error = function (message) {
-	return new Error(message);
-};
+  return new Error(message)
+}

--- a/test/fixtures/internal-error.js
+++ b/test/fixtures/internal-error.js
@@ -1,18 +1,18 @@
-'use strict';
-const NestedError = require('nested-error-stacks');
-const util = require('util');
+'use strict'
+const NestedError = require('nested-error-stacks')
+const util = require('util')
 
-function InternalError(message, nested) {
-	NestedError.call(this, message, nested);
+function InternalError (message, nested) {
+  NestedError.call(this, message, nested)
 }
 
-util.inherits(InternalError, NestedError);
-InternalError.prototype.name = 'InternalError';
+util.inherits(InternalError, NestedError)
+InternalError.prototype.name = 'InternalError'
 
 module.exports = (cb, err) => {
-	setTimeout(bound.bind(null, cb, err), 0);
-};
+  setTimeout(bound.bind(null, cb, err), 0)
+}
 
-function bound(cb, err) {
-	cb(new InternalError(`internal${err ? ': ' + err.message : ''}`, err));
+function bound (cb, err) {
+  cb(new InternalError(`internal${err ? ': ' + err.message : ''}`, err))
 }

--- a/test/fixtures/internal-error.js
+++ b/test/fixtures/internal-error.js
@@ -1,6 +1,6 @@
 'use strict';
-var NestedError = require('nested-error-stacks');
-var util = require('util');
+const NestedError = require('nested-error-stacks');
+const util = require('util');
 
 function InternalError(message, nested) {
 	NestedError.call(this, message, nested);
@@ -9,10 +9,10 @@ function InternalError(message, nested) {
 util.inherits(InternalError, NestedError);
 InternalError.prototype.name = 'InternalError';
 
-module.exports = function (cb, err) {
+module.exports = (cb, err) => {
 	setTimeout(bound.bind(null, cb, err), 0);
 };
 
 function bound(cb, err) {
-	cb(new InternalError('internal' + (err ? ': ' + err.message : ''), err));
+	cb(new InternalError(`internal${err ? ': ' + err.message : ''}`, err));
 }

--- a/test/fixtures/internal-then.js
+++ b/test/fixtures/internal-then.js
@@ -9,9 +9,6 @@ module.exports = function internalLibraryOuterFn(then) {
 
 module.exports.reject = function internalLibraryOuterReject() {
 	return global.InternalPromise.resolve().then(function internalLibraryInnerReject() {
-		return global.InternalPromise.reject(new Error('inner')).catch(function (e) {
-			return e.stack;
-		});
+		return global.InternalPromise.reject(new Error('inner')).catch(e => e.stack);
 	});
 };
-

--- a/test/fixtures/internal-then.js
+++ b/test/fixtures/internal-then.js
@@ -1,14 +1,14 @@
 
-//var p = global.InternalPromise.resolve().then(function () {});
+// var p = global.InternalPromise.resolve().then(function () {});
 
-module.exports = function internalLibraryOuterFn(then) {
-	return global.InternalPromise.resolve().then(function internalLibraryInnerFn() {
-		return global.InternalPromise.resolve().then(then);
-	});
-};
+module.exports = function internalLibraryOuterFn (then) {
+  return global.InternalPromise.resolve().then(function internalLibraryInnerFn () {
+    return global.InternalPromise.resolve().then(then)
+  })
+}
 
-module.exports.reject = function internalLibraryOuterReject() {
-	return global.InternalPromise.resolve().then(function internalLibraryInnerReject() {
-		return global.InternalPromise.reject(new Error('inner')).catch(e => e.stack);
-	});
-};
+module.exports.reject = function internalLibraryOuterReject () {
+  return global.InternalPromise.resolve().then(function internalLibraryInnerReject () {
+    return global.InternalPromise.reject(new Error('inner')).catch(e => e.stack)
+  })
+}

--- a/test/fixtures/long-stack-traces.js
+++ b/test/fixtures/long-stack-traces.js
@@ -1,16 +1,16 @@
-'use strict';
+'use strict'
 
-const Q = require('q');
-Q.longStackSupport = true;
-global.InternalPromise = Q;
-module.exports.q = require('./produce-long-stack-traces');
+const Q = require('q')
+Q.longStackSupport = true
+global.InternalPromise = Q
+module.exports.q = require('./produce-long-stack-traces')
 
-const longStackTracePath = require.resolve('./produce-long-stack-traces');
-const internalThen = require.resolve('./internal-then');
-delete require.cache[longStackTracePath];
-delete require.cache[internalThen];
+const longStackTracePath = require.resolve('./produce-long-stack-traces')
+const internalThen = require.resolve('./internal-then')
+delete require.cache[longStackTracePath]
+delete require.cache[internalThen]
 
-const bluebird = require('bluebird');
-bluebird.config({longStackTraces: true});
-global.InternalPromise = bluebird;
-module.exports.bluebird = require('./produce-long-stack-traces');
+const bluebird = require('bluebird')
+bluebird.config({longStackTraces: true})
+global.InternalPromise = bluebird
+module.exports.bluebird = require('./produce-long-stack-traces')

--- a/test/fixtures/long-stack-traces.js
+++ b/test/fixtures/long-stack-traces.js
@@ -1,16 +1,16 @@
 'use strict';
 
-var Q = require('q');
+const Q = require('q');
 Q.longStackSupport = true;
 global.InternalPromise = Q;
 module.exports.q = require('./produce-long-stack-traces');
 
-var longStackTracePath = require.resolve('./produce-long-stack-traces');
-var internalThen = require.resolve('./internal-then');
+const longStackTracePath = require.resolve('./produce-long-stack-traces');
+const internalThen = require.resolve('./internal-then');
 delete require.cache[longStackTracePath];
 delete require.cache[internalThen];
 
-var bluebird = require('bluebird');
+const bluebird = require('bluebird');
 bluebird.config({longStackTraces: true});
 global.InternalPromise = bluebird;
 module.exports.bluebird = require('./produce-long-stack-traces');

--- a/test/fixtures/nested-errors.js
+++ b/test/fixtures/nested-errors.js
@@ -1,49 +1,49 @@
-'use strict';
+'use strict'
 
-const NestedError = require('nested-error-stacks');
-const util = require('util');
-const internal = require('./internal-error');
+const NestedError = require('nested-error-stacks')
+const util = require('util')
+const internal = require('./internal-error')
 
-function foo(cb) {
-	bar(function nested(err) {
-		cb(new FooError('foo' + err.message, err));
-	});
+function foo (cb) {
+  bar(function nested (err) {
+    cb(new FooError('foo' + err.message, err))
+  })
 }
 
-function bar(cb) {
-	internal(function moreNested(err) {
-		cb(new BarError('bar: ' + err.message, err));
-	});
+function bar (cb) {
+  internal(function moreNested (err) {
+    cb(new BarError('bar: ' + err.message, err))
+  })
 }
 
-function FooError(message, nested) {
-	NestedError.call(this, message, nested);
+function FooError (message, nested) {
+  NestedError.call(this, message, nested)
 }
 
-util.inherits(FooError, NestedError);
-FooError.prototype.name = 'FooError';
+util.inherits(FooError, NestedError)
+FooError.prototype.name = 'FooError'
 
-function BarError(message, nested) {
-	NestedError.call(this, message, nested);
+function BarError (message, nested) {
+  NestedError.call(this, message, nested)
 }
 
-util.inherits(BarError, NestedError);
-BarError.prototype.name = 'BarError';
+util.inherits(BarError, NestedError)
+BarError.prototype.name = 'BarError'
 
-module.exports.top = function(cb) {
-	internal(function (err) {
-		cb(err.stack);
-	}, new Error('baz'));
-};
+module.exports.top = function (cb) {
+  internal(function (err) {
+    cb(err.stack)
+  }, new Error('baz'))
+}
 
 module.exports.middle = function (cb) {
-	internal(function (err) {
-		cb(new FooError('foo', err).stack);
-	}, new Error('bar'));
-};
+  internal(function (err) {
+    cb(new FooError('foo', err).stack)
+  }, new Error('bar'))
+}
 
 module.exports.bottom = function (cb) {
-	foo(function (err){
-		cb(err.stack);
-	});
-};
+  foo(function (err) {
+    cb(err.stack)
+  })
+}

--- a/test/fixtures/nested-errors.js
+++ b/test/fixtures/nested-errors.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var NestedError = require('nested-error-stacks');
-var util = require('util');
-var internal = require('./internal-error');
+const NestedError = require('nested-error-stacks');
+const util = require('util');
+const internal = require('./internal-error');
 
 function foo(cb) {
 	bar(function nested(err) {

--- a/test/fixtures/produce-long-stack-traces.js
+++ b/test/fixtures/produce-long-stack-traces.js
@@ -1,50 +1,50 @@
-'use strict';
+'use strict'
 
-const Promise = global.InternalPromise;
-const internalThen = require('./internal-then');
+const Promise = global.InternalPromise
+const internalThen = require('./internal-then')
 
-module.exports = Promise.resolve().then(function outer() {
-	return Promise.resolve().then(function inner() {
-		return Promise.resolve().then(function evenMoreInner() {
-			return Promise.resolve().then(function mostInner() {
-				a.b.c.d()
-			}).catch(function catcher(e) {
-				return e.stack;
-			});
-		});
-	});
-});
+module.exports = Promise.resolve().then(function outer () {
+  return Promise.resolve().then(function inner () {
+    return Promise.resolve().then(function evenMoreInner () {
+      return Promise.resolve().then(function mostInner () {
+        a.b.c.d() // eslint-disable-line no-undef
+      }).catch(function catcher (e) {
+        return e.stack
+      })
+    })
+  })
+})
 
-module.exports.middle = Promise.resolve().then(function outer() {
-	return Promise.resolve().then(function inner() {
-		return internalThen(function evenMoreInner() {
-			return Promise.resolve().then(function mostInner() {
-				a.b.c.d()
-			}).catch(function catcher(e) {
-				return e.stack;
-			});
-		});
-	});
-});
+module.exports.middle = Promise.resolve().then(function outer () {
+  return Promise.resolve().then(function inner () {
+    return internalThen(function evenMoreInner () {
+      return Promise.resolve().then(function mostInner () {
+        a.b.c.d() // eslint-disable-line no-undef
+      }).catch(function catcher (e) {
+        return e.stack
+      })
+    })
+  })
+})
 
-module.exports.top = Promise.resolve().then(function outer() {
-	return Promise.resolve().then(function inner() {
-		return Promise.resolve().then(function evenMoreInner() {
-			return Promise.resolve().then(internalThen.reject);
-		});
-	});
-});
+module.exports.top = Promise.resolve().then(function outer () {
+  return Promise.resolve().then(function inner () {
+    return Promise.resolve().then(function evenMoreInner () {
+      return Promise.resolve().then(internalThen.reject)
+    })
+  })
+})
 
 module.exports.bottom = new Promise(resolve => {
-	setTimeout(internalThen.bind(null, function outer() {
-		return Promise.resolve().then(function inner() {
-			return Promise.resolve().then(function evenMoreInner() {
-				return Promise.resolve().then(function mostInner() {
-					a.b.c.d()
-				}).catch(function catcher(e) {
-					resolve(e.stack);
-				});
-			});
-		});
-	}),0);
-});
+  setTimeout(internalThen.bind(null, function outer () {
+    return Promise.resolve().then(function inner () {
+      return Promise.resolve().then(function evenMoreInner () {
+        return Promise.resolve().then(function mostInner () {
+          a.b.c.d() // eslint-disable-line no-undef
+        }).catch(function catcher (e) {
+          resolve(e.stack)
+        })
+      })
+    })
+  }), 0)
+})

--- a/test/fixtures/produce-long-stack-traces.js
+++ b/test/fixtures/produce-long-stack-traces.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var Promise = global.InternalPromise;
-var internalThen = require('./internal-then');
+const Promise = global.InternalPromise;
+const internalThen = require('./internal-then');
 
 module.exports = Promise.resolve().then(function outer() {
 	return Promise.resolve().then(function inner() {
@@ -35,7 +35,7 @@ module.exports.top = Promise.resolve().then(function outer() {
 	});
 });
 
-module.exports.bottom = new Promise(function (resolve) {
+module.exports.bottom = new Promise(resolve => {
 	setTimeout(internalThen.bind(null, function outer() {
 		return Promise.resolve().then(function inner() {
 			return Promise.resolve().then(function evenMoreInner() {

--- a/test/long-stack-traces.js
+++ b/test/long-stack-traces.js
@@ -1,145 +1,145 @@
-'use strict';
+'use strict'
 
-const t = require('tap');
-const StackUtils = require('../');
-const longStackTraces = require('./fixtures/long-stack-traces');
-const pify = require('pify');
-const nestedErrors = pify(require('./fixtures/nested-errors'), Promise);
+const t = require('tap')
+const StackUtils = require('../')
+const longStackTraces = require('./fixtures/long-stack-traces')
+const pify = require('pify')
+const nestedErrors = pify(require('./fixtures/nested-errors'), Promise)
 
-const utils = require('./_utils');
+const utils = require('./_utils')
 
-function internals() {
+function internals () {
   return StackUtils.nodeInternals().concat([
     /\/long-stack-traces\.js:\d+:\d+\)?$/,
     /\/internal-error\.js:\d+:\d+\)?$/,
     /\/internal-then\.js:\d+:\d+\)?$/,
     /\/node_modules\//
-  ]);
+  ])
 }
 
-const stackUtils = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
+const stackUtils = new StackUtils({internals: internals(), cwd: utils.fixtureDir})
 
 t.test('indents lines after first "From previous event:"', t => {
   return longStackTraces.bluebird
     .then(stack => {
-      const cleanedStack = stackUtils.clean(stack);
+      const cleanedStack = stackUtils.clean(stack)
       const expected = utils.join([
-        'mostInner (produce-long-stack-traces.js:10:5)',
+        'mostInner (produce-long-stack-traces.js:10:9)',
         'From previous event:',
-        '    evenMoreInner (produce-long-stack-traces.js:9:29)',
+        '    evenMoreInner (produce-long-stack-traces.js:9:32)',
         'From previous event:',
-        '    inner (produce-long-stack-traces.js:8:28)',
+        '    inner (produce-long-stack-traces.js:8:30)',
         'From previous event:',
-        '    outer (produce-long-stack-traces.js:7:27)',
+        '    outer (produce-long-stack-traces.js:7:28)',
         'From previous event:',
         '    Object.<anonymous> (produce-long-stack-traces.js:6:36)'
-      ]);
+      ])
 
-      t.is(cleanedStack, expected);
-    });
-});
+      t.is(cleanedStack, expected)
+    })
+})
 
 t.test('removes empty "From previous event:" sections from the bottom', t => {
   return longStackTraces.bluebird.bottom
     .then(stack => {
-      const cleanedStack = stackUtils.clean(stack);
+      const cleanedStack = stackUtils.clean(stack)
 
       const expected = utils.join([
-        'mostInner (produce-long-stack-traces.js:43:6)',
+        'mostInner (produce-long-stack-traces.js:43:11)',
         'From previous event:',
-        '    evenMoreInner (produce-long-stack-traces.js:42:30)',
+        '    evenMoreInner (produce-long-stack-traces.js:42:34)',
         'From previous event:',
-        '    inner (produce-long-stack-traces.js:41:29)',
+        '    inner (produce-long-stack-traces.js:41:32)',
         'From previous event:',
-        '    outer (produce-long-stack-traces.js:40:28)'
-      ]);
+        '    outer (produce-long-stack-traces.js:40:30)'
+      ])
 
-      t.is(cleanedStack, expected);
-    });
-});
+      t.is(cleanedStack, expected)
+    })
+})
 
 t.test('removes empty "From previous event:" sections from the top', t => {
   return longStackTraces.bluebird.top
     .then(stack => {
-      const cleanedStack = stackUtils.clean(stack);
+      const cleanedStack = stackUtils.clean(stack)
 
       const expected = utils.join([
         'From previous event:',
-        '    evenMoreInner (produce-long-stack-traces.js:33:29)',
+        '    evenMoreInner (produce-long-stack-traces.js:33:32)',
         'From previous event:',
-        '    inner (produce-long-stack-traces.js:32:28)',
+        '    inner (produce-long-stack-traces.js:32:30)',
         'From previous event:',
-        '    outer (produce-long-stack-traces.js:31:27)',
+        '    outer (produce-long-stack-traces.js:31:28)',
         'From previous event:',
         '    Object.<anonymous> (produce-long-stack-traces.js:30:40)'
-      ]);
+      ])
 
-      t.is(cleanedStack, expected);
-    });
-});
+      t.is(cleanedStack, expected)
+    })
+})
 
 t.test('removes empty "From previous event:" sections from the middle', t => {
   return longStackTraces.bluebird.middle
     .then(stack => {
-      const cleanedStack = stackUtils.clean(stack);
+      const cleanedStack = stackUtils.clean(stack)
 
       const expected = utils.join([
-        'mostInner (produce-long-stack-traces.js:22:5)',
+        'mostInner (produce-long-stack-traces.js:22:9)',
         'From previous event:',
-        '    evenMoreInner (produce-long-stack-traces.js:21:29)',
+        '    evenMoreInner (produce-long-stack-traces.js:21:32)',
         'From previous event:',
-        '    inner (produce-long-stack-traces.js:20:10)',
+        '    inner (produce-long-stack-traces.js:20:12)',
         'From previous event:',
-        '    outer (produce-long-stack-traces.js:19:27)',
+        '    outer (produce-long-stack-traces.js:19:28)',
         'From previous event:',
         '    Object.<anonymous> (produce-long-stack-traces.js:18:43)'
-      ]);
+      ])
 
-      t.match(cleanedStack, expected);
-    });
-});
+      t.is(cleanedStack, expected)
+    })
+})
 
 t.test('removes empty "Caused by:" sections from the top', t => {
   nestedErrors.top(stack => {
-    const cleanedStack = stackUtils.clean(stack);
+    const cleanedStack = stackUtils.clean(stack)
 
     const expected = utils.join([
       'Caused By: Error: baz',
-      '    Object.module.exports.top (nested-errors.js:36:5)'
-    ]);
+      '    Object.module.exports.top (nested-errors.js:36:6)'
+    ])
 
-    t.match(cleanedStack, expected);
-    t.end();
-  });
-});
+    t.is(cleanedStack, expected)
+    t.end()
+  })
+})
 
 t.test('removes empty "Caused by:" sections from the bottom', t => {
   nestedErrors.bottom(stack => {
-    const cleanedStack = stackUtils.clean(stack);
+    const cleanedStack = stackUtils.clean(stack)
 
     const expected = utils.join([
-      'nested (nested-errors.js:9:6)',
-      'moreNested (nested-errors.js:15:3)',
+      'nested (nested-errors.js:9:8)',
+      'moreNested (nested-errors.js:15:5)',
       'Caused By: BarError: bar: internal',
-      '    moreNested (nested-errors.js:15:6)'
-    ]);
+      '    moreNested (nested-errors.js:15:8)'
+    ])
 
-    t.is(cleanedStack, expected);
-    t.end();
-  });
-});
+    t.is(cleanedStack, expected)
+    t.end()
+  })
+})
 
 t.test('removes empty "Caused by:" sections from the middle', t => {
   nestedErrors.middle(stack => {
-    const cleanedStack = stackUtils.clean(stack);
+    const cleanedStack = stackUtils.clean(stack)
 
     const expected = utils.join([
-      'nested-errors.js:41:6',
+      'nested-errors.js:41:8',
       'Caused By: Error: bar',
-      '    Object.module.exports.middle (nested-errors.js:42:5)'
-    ]);
+      '    Object.module.exports.middle (nested-errors.js:42:6)'
+    ])
 
-    t.match(cleanedStack, expected);
-    t.end();
-  });
-});
+    t.is(cleanedStack, expected)
+    t.end()
+  })
+})

--- a/test/long-stack-traces.js
+++ b/test/long-stack-traces.js
@@ -1,10 +1,12 @@
+'use strict';
+
 const t = require('tap');
 const StackUtils = require('../');
 const longStackTraces = require('./fixtures/long-stack-traces');
 const pify = require('pify');
 const nestedErrors = pify(require('./fixtures/nested-errors'), Promise);
 
-const {join, fixtureDir} = require('./_utils');
+const utils = require('./_utils');
 
 function internals() {
   return StackUtils.nodeInternals().concat([
@@ -15,84 +17,93 @@ function internals() {
   ]);
 }
 
-const stackUtils = new StackUtils({internals: internals(), cwd: fixtureDir});
+const stackUtils = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
 
-t.test('indents lines after first "From previous event:"', async t => {
-  const cleanedStack = stackUtils.clean(await longStackTraces.bluebird);
-  const expected = join([
-    'mostInner (produce-long-stack-traces.js:10:5)',
-    'From previous event:',
-    '    evenMoreInner (produce-long-stack-traces.js:9:29)',
-    'From previous event:',
-    '    inner (produce-long-stack-traces.js:8:28)',
-    'From previous event:',
-    '    outer (produce-long-stack-traces.js:7:27)',
-    'From previous event:',
-    '    Object.<anonymous> (produce-long-stack-traces.js:6:36)'
-  ]);
+t.test('indents lines after first "From previous event:"', t => {
+  return longStackTraces.bluebird
+    .then(stack => {
+      const cleanedStack = stackUtils.clean(stack);
+      const expected = utils.join([
+        'mostInner (produce-long-stack-traces.js:10:5)',
+        'From previous event:',
+        '    evenMoreInner (produce-long-stack-traces.js:9:29)',
+        'From previous event:',
+        '    inner (produce-long-stack-traces.js:8:28)',
+        'From previous event:',
+        '    outer (produce-long-stack-traces.js:7:27)',
+        'From previous event:',
+        '    Object.<anonymous> (produce-long-stack-traces.js:6:36)'
+      ]);
 
-  t.is(cleanedStack, expected);
+      t.is(cleanedStack, expected);
+    });
 });
 
-t.test('removes empty "From previous event:" sections from the bottom', async t => {
-  const stack = await longStackTraces.bluebird.bottom;
-  const cleanedStack = stackUtils.clean(stack);
+t.test('removes empty "From previous event:" sections from the bottom', t => {
+  return longStackTraces.bluebird.bottom
+    .then(stack => {
+      const cleanedStack = stackUtils.clean(stack);
 
-  const expected = join([
-    'mostInner (produce-long-stack-traces.js:43:6)',
-    'From previous event:',
-    '    evenMoreInner (produce-long-stack-traces.js:42:30)',
-    'From previous event:',
-    '    inner (produce-long-stack-traces.js:41:29)',
-    'From previous event:',
-    '    outer (produce-long-stack-traces.js:40:28)'
-  ]);
+      const expected = utils.join([
+        'mostInner (produce-long-stack-traces.js:43:6)',
+        'From previous event:',
+        '    evenMoreInner (produce-long-stack-traces.js:42:30)',
+        'From previous event:',
+        '    inner (produce-long-stack-traces.js:41:29)',
+        'From previous event:',
+        '    outer (produce-long-stack-traces.js:40:28)'
+      ]);
 
-  t.is(cleanedStack, expected);
+      t.is(cleanedStack, expected);
+    });
 });
 
-t.test('removes empty "From previous event:" sections from the top', async t => {
-  const stack = await longStackTraces.bluebird.top;
-  const cleanedStack = stackUtils.clean(stack);
+t.test('removes empty "From previous event:" sections from the top', t => {
+  return longStackTraces.bluebird.top
+    .then(stack => {
+      const cleanedStack = stackUtils.clean(stack);
 
-  const expected = join([
-    'From previous event:',
-    '    evenMoreInner (produce-long-stack-traces.js:33:29)',
-    'From previous event:',
-    '    inner (produce-long-stack-traces.js:32:28)',
-    'From previous event:',
-    '    outer (produce-long-stack-traces.js:31:27)',
-    'From previous event:',
-    '    Object.<anonymous> (produce-long-stack-traces.js:30:40)'
-  ]);
+      const expected = utils.join([
+        'From previous event:',
+        '    evenMoreInner (produce-long-stack-traces.js:33:29)',
+        'From previous event:',
+        '    inner (produce-long-stack-traces.js:32:28)',
+        'From previous event:',
+        '    outer (produce-long-stack-traces.js:31:27)',
+        'From previous event:',
+        '    Object.<anonymous> (produce-long-stack-traces.js:30:40)'
+      ]);
 
-  t.is(cleanedStack, expected);
+      t.is(cleanedStack, expected);
+    });
 });
 
-t.test('removes empty "From previous event:" sections from the middle', async t => {
-  const stack = await longStackTraces.bluebird.middle;
-  const cleanedStack = stackUtils.clean(stack);
+t.test('removes empty "From previous event:" sections from the middle', t => {
+  return longStackTraces.bluebird.middle
+    .then(stack => {
+      const cleanedStack = stackUtils.clean(stack);
 
-  const expected = join([
-    'mostInner (produce-long-stack-traces.js:22:5)',
-    'From previous event:',
-    '    evenMoreInner (produce-long-stack-traces.js:21:29)',
-    'From previous event:',
-    '    inner (produce-long-stack-traces.js:20:10)',
-    'From previous event:',
-    '    outer (produce-long-stack-traces.js:19:27)',
-    'From previous event:',
-    '    Object.<anonymous> (produce-long-stack-traces.js:18:43)'
-  ]);
+      const expected = utils.join([
+        'mostInner (produce-long-stack-traces.js:22:5)',
+        'From previous event:',
+        '    evenMoreInner (produce-long-stack-traces.js:21:29)',
+        'From previous event:',
+        '    inner (produce-long-stack-traces.js:20:10)',
+        'From previous event:',
+        '    outer (produce-long-stack-traces.js:19:27)',
+        'From previous event:',
+        '    Object.<anonymous> (produce-long-stack-traces.js:18:43)'
+      ]);
 
-  t.match(cleanedStack, expected);
+      t.match(cleanedStack, expected);
+    });
 });
 
 t.test('removes empty "Caused by:" sections from the top', t => {
   nestedErrors.top(stack => {
     const cleanedStack = stackUtils.clean(stack);
 
-    const expected = join([
+    const expected = utils.join([
       'Caused By: Error: baz',
       '    Object.module.exports.top (nested-errors.js:36:5)'
     ]);
@@ -106,7 +117,7 @@ t.test('removes empty "Caused by:" sections from the bottom', t => {
   nestedErrors.bottom(stack => {
     const cleanedStack = stackUtils.clean(stack);
 
-    const expected = join([
+    const expected = utils.join([
       'nested (nested-errors.js:9:6)',
       'moreNested (nested-errors.js:15:3)',
       'Caused By: BarError: bar: internal',
@@ -122,7 +133,7 @@ t.test('removes empty "Caused by:" sections from the middle', t => {
   nestedErrors.middle(stack => {
     const cleanedStack = stackUtils.clean(stack);
 
-    const expected = join([
+    const expected = utils.join([
       'nested-errors.js:41:6',
       'Caused By: Error: bar',
       '    Object.module.exports.middle (nested-errors.js:42:5)'

--- a/test/test.js
+++ b/test/test.js
@@ -378,6 +378,14 @@ t.test('parseLine', t => {
     function: 'SomeClass.someFunc'
   })
 
+  // { "foo bar" () { throw new Error() } }
+  t.same(stack.parseLine('    at Object.foo bar (/user/dev/project/foo.js:3:8)'), {
+    file: 'foo.js',
+    line: 3,
+    column: 8,
+    function: 'Object.foo bar'
+  });
+
   t.same(stack.parseLine('    at foo (/some/other/dir/file.js:3:8)'), {
     file: '/some/other/dir/file.js',
     line: 3,

--- a/test/test.js
+++ b/test/test.js
@@ -1,10 +1,10 @@
-'use strict';
+'use strict'
 
-const path = require('path');
-const t = require('tap');
-const StackUtils = require('../');
-const CaptureFixture = require('./fixtures/capture-fixture');
-const utils = require('./_utils');
+const path = require('path')
+const t = require('tap')
+const StackUtils = require('../')
+const CaptureFixture = require('./fixtures/capture-fixture')
+const utils = require('./_utils')
 
 // Use a fixed known set of native modules, since this changes
 // depending on the version of Node we're testing with.
@@ -96,17 +96,17 @@ StackUtils.natives = [
   'v8/tools/tickprocessor-driver',
   'bootstrap_node',
   'node'
-];
+]
 
-const LinuxStack1 = utils.join(linuxStack1(), internalStack());
-const WindowsStack1 = utils.join(windowsStack1(), internalStack());
+const LinuxStack1 = utils.join(linuxStack1(), internalStack())
+const WindowsStack1 = utils.join(windowsStack1(), internalStack())
 
 t.test('must be called with new', t => {
-  t.is(typeof StackUtils, 'function');
-  const stackUtils = StackUtils;
-  t.throws(() => stackUtils());
+  t.is(typeof StackUtils, 'function')
+  const stackUtils = StackUtils
+  t.throws(() => stackUtils())
   t.end()
-});
+})
 
 t.test('clean: truncates cwd', t => {
   const expected = utils.join([
@@ -129,261 +129,261 @@ t.test('clean: truncates cwd', t => {
     'startup (bootstrap_node.js:139:9)',
     'bootstrap_node.js:535:3',
     'startup (node.js:141:18)'
-  ]);
+  ])
 
-  let stack = new StackUtils({cwd: '/user/dev/project'});
-  t.is(stack.clean(LinuxStack1), expected, 'accepts a linux string');
-  t.is(stack.clean(LinuxStack1.split('\n')), expected, 'accepts an array');
-  t.is(stack.clean(LinuxStack1.split('\n').slice(1)), expected, 'slices off the message line');
+  let stack = new StackUtils({cwd: '/user/dev/project'})
+  t.is(stack.clean(LinuxStack1), expected, 'accepts a linux string')
+  t.is(stack.clean(LinuxStack1.split('\n')), expected, 'accepts an array')
+  t.is(stack.clean(LinuxStack1.split('\n').slice(1)), expected, 'slices off the message line')
 
-  stack = new StackUtils({cwd: 'Z:\\user\\dev\\project'});
-  t.is(stack.clean(WindowsStack1), expected, 'accepts a windows string');
+  stack = new StackUtils({cwd: 'Z:\\user\\dev\\project'})
+  t.is(stack.clean(WindowsStack1), expected, 'accepts a windows string')
   t.end()
-});
+})
 
 t.test('clean: eliminates internals', t => {
-  let stack = new StackUtils({cwd: '/user/dev', internals: StackUtils.nodeInternals()});
+  let stack = new StackUtils({cwd: '/user/dev', internals: StackUtils.nodeInternals()})
   var expected = utils.join([
     'foo (project/foo.js:3:8)',
     'bar (project/foo.js:7:2)',
     'bar (project/bar.js:4:2)',
     'Object.<anonymous> (project/bar.js:7:1)'
-  ]);
-  t.is(stack.clean(LinuxStack1), expected);
+  ])
+  t.is(stack.clean(LinuxStack1), expected)
 
-  stack = new StackUtils({cwd: 'Z:\\user\\dev', internals: StackUtils.nodeInternals()});
-  t.is(stack.clean(WindowsStack1), expected);
+  stack = new StackUtils({cwd: 'Z:\\user\\dev', internals: StackUtils.nodeInternals()})
+  t.is(stack.clean(WindowsStack1), expected)
   t.end()
-});
+})
 
 t.test('clean: returns null if it is all internals', t => {
-  const stack = new StackUtils({internals: StackUtils.nodeInternals()});
-  t.is(stack.clean(utils.join(internalStack())), '');
+  const stack = new StackUtils({internals: StackUtils.nodeInternals()})
+  t.is(stack.clean(utils.join(internalStack())), '')
   t.end()
-});
+})
 
 t.test('captureString: two redirects', t => {
-  const stack = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
-  const capture = new CaptureFixture(stack);
+  const stack = new StackUtils({internals: internals(), cwd: utils.fixtureDir})
+  const capture = new CaptureFixture(stack)
 
-  const capturedString = capture.redirect1('redirect2', 'call', 'captureString');
+  const capturedString = capture.redirect1('redirect2', 'call', 'captureString')
   t.is(capturedString, utils.join([
-    'CaptureFixture.call (capture-fixture.js:23:28)',
-    'CaptureFixture.redirect2 (capture-fixture.js:17:22)',
-    'CaptureFixture.redirect1 (capture-fixture.js:11:22)'
-  ]));
+    'CaptureFixture.call (capture-fixture.js:23:29)',
+    'CaptureFixture.redirect2 (capture-fixture.js:17:23)',
+    'CaptureFixture.redirect1 (capture-fixture.js:11:23)'
+  ]))
   t.end()
-});
+})
 
 t.test('captureString: with startStack function', t => {
-  const stack = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
-  const capture = new CaptureFixture(stack);
+  const stack = new StackUtils({internals: internals(), cwd: utils.fixtureDir})
+  const capture = new CaptureFixture(stack)
 
-  const capturedString = capture.redirect1('redirect2', 'call', 'captureString', capture.call);
+  const capturedString = capture.redirect1('redirect2', 'call', 'captureString', capture.call)
   t.is(capturedString, utils.join([
-    'CaptureFixture.redirect2 (capture-fixture.js:17:22)',
-    'CaptureFixture.redirect1 (capture-fixture.js:11:22)'
-  ]));
+    'CaptureFixture.redirect2 (capture-fixture.js:17:23)',
+    'CaptureFixture.redirect1 (capture-fixture.js:11:23)'
+  ]))
   t.end()
-});
+})
 
 t.test('captureString: with limit', t => {
-  const stack = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
-  const capture = new CaptureFixture(stack);
+  const stack = new StackUtils({internals: internals(), cwd: utils.fixtureDir})
+  const capture = new CaptureFixture(stack)
 
-  const capturedString = capture.redirect1('redirect2', 'call', 'captureString', 1);
+  const capturedString = capture.redirect1('redirect2', 'call', 'captureString', 1)
   t.is(capturedString, utils.join([
-    'CaptureFixture.call (capture-fixture.js:23:28)'
-  ]));
+    'CaptureFixture.call (capture-fixture.js:23:29)'
+  ]))
   t.end()
-});
+})
 
 t.test('captureString: with limit and startStack', t => {
-  const stack = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
-  const capture = new CaptureFixture(stack);
+  const stack = new StackUtils({internals: internals(), cwd: utils.fixtureDir})
+  const capture = new CaptureFixture(stack)
 
-  const capturedString = capture.redirect1('redirect2', 'call', 'captureString', 1, capture.call);
+  const capturedString = capture.redirect1('redirect2', 'call', 'captureString', 1, capture.call)
   t.is(capturedString, utils.join([
-    'CaptureFixture.redirect2 (capture-fixture.js:17:22)'
-  ]));
+    'CaptureFixture.redirect2 (capture-fixture.js:17:23)'
+  ]))
   t.end()
-});
+})
 
 t.test('capture returns an array of call sites', t => {
-  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
-  const capture = new CaptureFixture(stackUtil);
-  const stack = capture.redirect1('call', 'capture').slice(0, 2);
-  t.is(stack[0].getFileName(), path.join(utils.fixtureDir, 'capture-fixture.js'));
-  t.is(stack[0].getFunctionName(), 'CaptureFixture.call');
-  t.is(stack[1].getFunctionName(), 'CaptureFixture.redirect1');
+  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir})
+  const capture = new CaptureFixture(stackUtil)
+  const stack = capture.redirect1('call', 'capture').slice(0, 2)
+  t.is(stack[0].getFileName(), path.join(utils.fixtureDir, 'capture-fixture.js'))
+  t.is(stack[0].getFunctionName(), 'CaptureFixture.call')
+  t.is(stack[1].getFunctionName(), 'CaptureFixture.redirect1')
   t.end()
-});
+})
 
 t.test('capture: with limit', t => {
-  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
-  const capture = new CaptureFixture(stackUtil);
-  const stack = capture.redirect1('redirect2', 'call', 'capture', 1);
-  t.is(stack.length, 1);
-  t.is(stack[0].getFunctionName(), 'CaptureFixture.call');
+  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir})
+  const capture = new CaptureFixture(stackUtil)
+  const stack = capture.redirect1('redirect2', 'call', 'capture', 1)
+  t.is(stack.length, 1)
+  t.is(stack[0].getFunctionName(), 'CaptureFixture.call')
   t.end()
-});
+})
 
 t.test('capture: with stackStart function', t => {
-  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
-  const capture = new CaptureFixture(stackUtil);
-  const stack = capture.redirect1('redirect2', 'call', 'capture', capture.call);
-  t.true(stack.length > 1);
-  t.is(stack[0].getFunctionName(), 'CaptureFixture.redirect2');
+  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir})
+  const capture = new CaptureFixture(stackUtil)
+  const stack = capture.redirect1('redirect2', 'call', 'capture', capture.call)
+  t.true(stack.length > 1)
+  t.is(stack[0].getFunctionName(), 'CaptureFixture.redirect2')
   t.end()
-});
+})
 
 t.test('capture: with limit and stackStart function', t => {
-  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
-  const capture = new CaptureFixture(stackUtil);
-  const stack = capture.redirect1('redirect2', 'call', 'capture', 1, capture.call);
-  t.is(stack.length, 1);
-  t.is(stack[0].getFunctionName(), 'CaptureFixture.redirect2');
+  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir})
+  const capture = new CaptureFixture(stackUtil)
+  const stack = capture.redirect1('redirect2', 'call', 'capture', 1, capture.call)
+  t.is(stack.length, 1)
+  t.is(stack[0].getFunctionName(), 'CaptureFixture.redirect2')
   t.end()
-});
+})
 
 t.test('capture: with wrapCallSite function', t => {
   const wrapper = function (callsite) {
     return {
       getMethodName: function () {
-        return callsite.getMethodName();
+        return callsite.getMethodName()
       },
       getFunctionName: function () {
-        return 'testOverrideFunctionName';
+        return 'testOverrideFunctionName'
       }
-    };
-  };
-  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir, wrapCallSite: wrapper});
-  const capture = new CaptureFixture(stackUtil);
-  const stack = capture.redirect1('redirect2', 'call', 'capture', 1, capture.call);
-  t.is(stack.length, 1);
-  t.is(stack[0].getFunctionName(), 'testOverrideFunctionName');
-  t.is(stack[0].getMethodName(), 'redirect2');
+    }
+  }
+  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir, wrapCallSite: wrapper})
+  const capture = new CaptureFixture(stackUtil)
+  const stack = capture.redirect1('redirect2', 'call', 'capture', 1, capture.call)
+  t.is(stack.length, 1)
+  t.is(stack[0].getFunctionName(), 'testOverrideFunctionName')
+  t.is(stack[0].getMethodName(), 'redirect2')
   t.end()
-});
+})
 
 t.test('at', t => {
-  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
-  const capture = new CaptureFixture(stackUtil);
-  const at = capture.redirect1('call', 'at');
+  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir})
+  const capture = new CaptureFixture(stackUtil)
+  const at = capture.redirect1('call', 'at')
 
   t.same(at, {
     file: 'capture-fixture.js',
     line: 23,
-    column: 28,
+    column: 29,
     type: 'CaptureFixture',
     function: 'CaptureFixture.call',
     method: 'call'
-  });
+  })
   t.end()
-});
+})
 
 t.test('at: with stackStart', t => {
-  const stackUtil = new StackUtils({internals: internals(), cwd: __dirname});
-  const capture = new CaptureFixture(stackUtil);
+  const stackUtil = new StackUtils({internals: internals(), cwd: __dirname})
+  const capture = new CaptureFixture(stackUtil)
 
-  const at = capture.redirect1('call', 'at', capture.call);
+  const at = capture.redirect1('call', 'at', capture.call)
 
   t.same(at, {
     file: `fixtures/capture-fixture.js`,
     line: 11,
-    column: 22,
+    column: 23,
     type: 'CaptureFixture',
     function: 'CaptureFixture.redirect1',
     method: 'redirect1'
-  });
+  })
   t.end()
-});
+})
 
 t.test('at: inside a constructor call', t => {
-  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
-  const capture = new CaptureFixture(stackUtil);
+  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir})
+  const capture = new CaptureFixture(stackUtil)
 
-  const at = capture.const('call', 'at', capture.call);
+  const at = capture.const('call', 'at', capture.call)
 
   // TODO: File an issue - if this assert fails, the power assert diagram renderer blows up.
   t.same(at, {
     file: 'capture-fixture.js',
     line: 32,
-    column: 27,
+    column: 29,
     constructor: true,
     type: 'Constructor',
     function: 'Constructor'
-  });
+  })
   t.end()
-});
+})
 
 t.test('at: method on an [Object] instance', t => {
-  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
-  const capture = new CaptureFixture(stackUtil);
+  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir})
+  const capture = new CaptureFixture(stackUtil)
 
-  const at = capture.const('obj', 'foo', 'call', 'at', capture.call);
+  const at = capture.const('obj', 'foo', 'call', 'at', capture.call)
 
   t.same(at, {
     file: 'capture-fixture.js',
     line: 46,
-    column: 23,
+    column: 25,
     function: 'obj.(anonymous function)',
     method: 'foo'
-  });
+  })
   t.end()
-});
+})
 
 t.test('at: returns empty object if #capture() returns an empty stack', t => {
-  const stackUtil = new StackUtils();
+  const stackUtil = new StackUtils()
   stackUtil.capture = function () {
-    return [];
-  };
-  t.same(stackUtil.at(), {});
+    return []
+  }
+  t.same(stackUtil.at(), {})
   t.end()
-});
+})
 
 t.test('at: eval', t => {
-  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
-  const capture = new CaptureFixture(stackUtil);
+  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir})
+  const capture = new CaptureFixture(stackUtil)
 
-  const at = capture.eval('call', 'at', capture.call);
+  const at = capture.eval('call', 'at', capture.call)
   const expected = {
     line: 1,
     column: 14,
-    evalOrigin: /eval at (<anonymous>|CaptureFixture.eval) \(.*capture-fixture.js:57:9\)/,
+    evalOrigin: /eval at (<anonymous>|CaptureFixture.eval) \(.*capture-fixture.js:57:10\)/,
     function: 'eval'
-  };
+  }
 
-  t.match(at, expected);
+  t.match(at, expected)
   t.end()
-});
+})
 
 t.test('parseLine', t => {
-  const stack = new StackUtils({internals: internals(), cwd: '/user/dev/project'});
-  const capture = new CaptureFixture(stack);
+  const stack = new StackUtils({internals: internals(), cwd: '/user/dev/project'})
+  const capture = new CaptureFixture(stack)
 
-  t.same(stack.parseLine('foo'), null, 'should not match');
+  t.same(stack.parseLine('foo'), null, 'should not match')
 
   t.same(stack.parseLine('    at bar (/user/dev/project/foo.js:3:8)'), {
     file: 'foo.js',
     line: 3,
     column: 8,
     function: 'bar'
-  });
+  })
 
   t.same(stack.parseLine('    at SomeClass.someFunc (/user/dev/project/foo.js:3:8)'), {
     file: 'foo.js',
     line: 3,
     column: 8,
     function: 'SomeClass.someFunc'
-  });
+  })
 
   t.same(stack.parseLine('    at foo (/some/other/dir/file.js:3:8)'), {
     file: '/some/other/dir/file.js',
     line: 3,
     column: 8,
     function: 'foo'
-  });
+  })
 
   // TODO: report issue - this also causes power-assert diagram renderer to fail
   t.same(stack.parseLine('    at new Foo (/user/dev/project/foo.js:3:8)'), {
@@ -392,10 +392,10 @@ t.test('parseLine', t => {
     column: 8,
     constructor: true,
     function: 'Foo'
-  });
+  })
 
   // EVAL
-  const evalStack = capture.eval('error', 'foo').stack.split('\n');
+  const evalStack = capture.eval('error', 'foo').stack.split('\n')
 
   const expected = {
     file: '<anonymous>',
@@ -403,57 +403,57 @@ t.test('parseLine', t => {
     column: 14,
     evalOrigin: /CaptureFixture.eval|<anonymous>/,
     evalLine: 57,
-    evalColumn: 9,
+    evalColumn: 10,
     evalFile: path.join(utils.fixtureDir, 'capture-fixture.js').replace(/\\/g, '/'),
     function: 'eval'
-  };
+  }
 
-  const actual = stack.parseLine(evalStack[2]);
+  const actual = stack.parseLine(evalStack[2])
 
-  t.match(actual, expected);
+  t.match(actual, expected)
   t.end()
-});
+})
 
 t.test('parseLine: handles native errors', t => {
   t.same(StackUtils.parseLine('    at Error (native)'), {
     native: true,
     function: 'Error'
-  });
+  })
   t.end()
-});
+})
 
 t.test('parseLine: handles parens', t => {
-  var line = '    at X.<anonymous> (/USER/Db (Person)/x/y.js:14:11)';
+  var line = '    at X.<anonymous> (/USER/Db (Person)/x/y.js:14:11)'
   t.same(StackUtils.parseLine(line), {
     line: 14,
     column: 11,
     file: '/USER/Db (Person)/x/y.js',
     function: 'X.<anonymous>'
-  });
+  })
   t.end()
-});
+})
 
-function linuxStack1() {
+function linuxStack1 () {
   return [
     'Error: foo',
     '    at foo (/user/dev/project/foo.js:3:8)',
     '    at bar (/user/dev/project/foo.js:7:2)',
     '    at bar (/user/dev/project/bar.js:4:2)',
     '    at Object.<anonymous> (/user/dev/project/bar.js:7:1)'
-  ];
+  ]
 }
 
-function windowsStack1() {
+function windowsStack1 () {
   return [
     'Error: foo',
     '    at foo (Z:\\user\\dev\\project\\foo.js:3:8)',
     '    at bar (Z:\\user\\dev\\project\\foo.js:7:2)',
     '    at bar (Z:\\user\\dev\\project\\bar.js:4:2)',
     '    at Object.<anonymous> (Z:\\user\\dev\\project\\bar.js:7:1)'
-  ];
+  ]
 }
 
-function internalStack() {
+function internalStack () {
   return [
     '    at ontimeout (timers.js:365:14)',
     '    at tryOnTimeout (timers.js:237:5)',
@@ -470,12 +470,12 @@ function internalStack() {
     '    at startup (bootstrap_node.js:139:9)',
     '    at bootstrap_node.js:535:3',
     '    at startup (node.js:141:18)'
-  ];
+  ]
 }
 
-function internals() {
+function internals () {
   return StackUtils.nodeInternals().concat([
     /test\.js:\d+:\d+\)?$/,
     /\/node_modules\//
-  ]);
+  ])
 }

--- a/test/test.js
+++ b/test/test.js
@@ -384,7 +384,15 @@ t.test('parseLine', t => {
     line: 3,
     column: 8,
     function: 'Object.foo bar'
-  });
+  })
+
+  // Array.from({ *[Symbol.iterator] () { throw new Error() } })
+  t.same(stack.parseLine('    at Object.[Symbol.iterator] (/user/dev/project/foo.js:3:8)'), {
+    file: 'foo.js',
+    line: 3,
+    column: 8,
+    function: 'Object.[Symbol.iterator]'
+  })
 
   t.same(stack.parseLine('    at foo (/some/other/dir/file.js:3:8)'), {
     file: '/some/other/dir/file.js',

--- a/test/test.js
+++ b/test/test.js
@@ -1,8 +1,10 @@
+'use strict';
+
 const path = require('path');
 const t = require('tap');
 const StackUtils = require('../');
 const CaptureFixture = require('./fixtures/capture-fixture');
-const {join, fixtureDir} = require('./_utils');
+const utils = require('./_utils');
 
 // Use a fixed known set of native modules, since this changes
 // depending on the version of Node we're testing with.
@@ -96,8 +98,8 @@ StackUtils.natives = [
   'node'
 ];
 
-const LinuxStack1 = join(linuxStack1(), internalStack());
-const WindowsStack1 = join(windowsStack1(), internalStack());
+const LinuxStack1 = utils.join(linuxStack1(), internalStack());
+const WindowsStack1 = utils.join(windowsStack1(), internalStack());
 
 t.test('must be called with new', t => {
   t.is(typeof StackUtils, 'function');
@@ -107,7 +109,7 @@ t.test('must be called with new', t => {
 });
 
 t.test('clean: truncates cwd', t => {
-  const expected = join([
+  const expected = utils.join([
     'foo (foo.js:3:8)',
     'bar (foo.js:7:2)',
     'bar (bar.js:4:2)',
@@ -141,7 +143,7 @@ t.test('clean: truncates cwd', t => {
 
 t.test('clean: eliminates internals', t => {
   let stack = new StackUtils({cwd: '/user/dev', internals: StackUtils.nodeInternals()});
-  var expected = join([
+  var expected = utils.join([
     'foo (project/foo.js:3:8)',
     'bar (project/foo.js:7:2)',
     'bar (project/bar.js:4:2)',
@@ -156,16 +158,16 @@ t.test('clean: eliminates internals', t => {
 
 t.test('clean: returns null if it is all internals', t => {
   const stack = new StackUtils({internals: StackUtils.nodeInternals()});
-  t.is(stack.clean(join(internalStack())), '');
+  t.is(stack.clean(utils.join(internalStack())), '');
   t.end()
 });
 
 t.test('captureString: two redirects', t => {
-  const stack = new StackUtils({internals: internals(), cwd: fixtureDir});
+  const stack = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
   const capture = new CaptureFixture(stack);
 
   const capturedString = capture.redirect1('redirect2', 'call', 'captureString');
-  t.is(capturedString, join([
+  t.is(capturedString, utils.join([
     'CaptureFixture.call (capture-fixture.js:23:28)',
     'CaptureFixture.redirect2 (capture-fixture.js:17:22)',
     'CaptureFixture.redirect1 (capture-fixture.js:11:22)'
@@ -174,11 +176,11 @@ t.test('captureString: two redirects', t => {
 });
 
 t.test('captureString: with startStack function', t => {
-  const stack = new StackUtils({internals: internals(), cwd: fixtureDir});
+  const stack = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
   const capture = new CaptureFixture(stack);
 
   const capturedString = capture.redirect1('redirect2', 'call', 'captureString', capture.call);
-  t.is(capturedString, join([
+  t.is(capturedString, utils.join([
     'CaptureFixture.redirect2 (capture-fixture.js:17:22)',
     'CaptureFixture.redirect1 (capture-fixture.js:11:22)'
   ]));
@@ -186,39 +188,39 @@ t.test('captureString: with startStack function', t => {
 });
 
 t.test('captureString: with limit', t => {
-  const stack = new StackUtils({internals: internals(), cwd: fixtureDir});
+  const stack = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
   const capture = new CaptureFixture(stack);
 
   const capturedString = capture.redirect1('redirect2', 'call', 'captureString', 1);
-  t.is(capturedString, join([
+  t.is(capturedString, utils.join([
     'CaptureFixture.call (capture-fixture.js:23:28)'
   ]));
   t.end()
 });
 
 t.test('captureString: with limit and startStack', t => {
-  const stack = new StackUtils({internals: internals(), cwd: fixtureDir});
+  const stack = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
   const capture = new CaptureFixture(stack);
 
   const capturedString = capture.redirect1('redirect2', 'call', 'captureString', 1, capture.call);
-  t.is(capturedString, join([
+  t.is(capturedString, utils.join([
     'CaptureFixture.redirect2 (capture-fixture.js:17:22)'
   ]));
   t.end()
 });
 
 t.test('capture returns an array of call sites', t => {
-  const stackUtil = new StackUtils({internals: internals(), cwd: fixtureDir});
+  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
   const capture = new CaptureFixture(stackUtil);
   const stack = capture.redirect1('call', 'capture').slice(0, 2);
-  t.is(stack[0].getFileName(), path.join(fixtureDir, 'capture-fixture.js'));
+  t.is(stack[0].getFileName(), path.join(utils.fixtureDir, 'capture-fixture.js'));
   t.is(stack[0].getFunctionName(), 'CaptureFixture.call');
   t.is(stack[1].getFunctionName(), 'CaptureFixture.redirect1');
   t.end()
 });
 
 t.test('capture: with limit', t => {
-  const stackUtil = new StackUtils({internals: internals(), cwd: fixtureDir});
+  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
   const capture = new CaptureFixture(stackUtil);
   const stack = capture.redirect1('redirect2', 'call', 'capture', 1);
   t.is(stack.length, 1);
@@ -227,7 +229,7 @@ t.test('capture: with limit', t => {
 });
 
 t.test('capture: with stackStart function', t => {
-  const stackUtil = new StackUtils({internals: internals(), cwd: fixtureDir});
+  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
   const capture = new CaptureFixture(stackUtil);
   const stack = capture.redirect1('redirect2', 'call', 'capture', capture.call);
   t.true(stack.length > 1);
@@ -236,7 +238,7 @@ t.test('capture: with stackStart function', t => {
 });
 
 t.test('capture: with limit and stackStart function', t => {
-  const stackUtil = new StackUtils({internals: internals(), cwd: fixtureDir});
+  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
   const capture = new CaptureFixture(stackUtil);
   const stack = capture.redirect1('redirect2', 'call', 'capture', 1, capture.call);
   t.is(stack.length, 1);
@@ -255,7 +257,7 @@ t.test('capture: with wrapCallSite function', t => {
       }
     };
   };
-  const stackUtil = new StackUtils({internals: internals(), cwd: fixtureDir, wrapCallSite: wrapper});
+  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir, wrapCallSite: wrapper});
   const capture = new CaptureFixture(stackUtil);
   const stack = capture.redirect1('redirect2', 'call', 'capture', 1, capture.call);
   t.is(stack.length, 1);
@@ -265,7 +267,7 @@ t.test('capture: with wrapCallSite function', t => {
 });
 
 t.test('at', t => {
-  const stackUtil = new StackUtils({internals: internals(), cwd: fixtureDir});
+  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
   const capture = new CaptureFixture(stackUtil);
   const at = capture.redirect1('call', 'at');
 
@@ -298,7 +300,7 @@ t.test('at: with stackStart', t => {
 });
 
 t.test('at: inside a constructor call', t => {
-  const stackUtil = new StackUtils({internals: internals(), cwd: fixtureDir});
+  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
   const capture = new CaptureFixture(stackUtil);
 
   const at = capture.const('call', 'at', capture.call);
@@ -316,7 +318,7 @@ t.test('at: inside a constructor call', t => {
 });
 
 t.test('at: method on an [Object] instance', t => {
-  const stackUtil = new StackUtils({internals: internals(), cwd: fixtureDir});
+  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
   const capture = new CaptureFixture(stackUtil);
 
   const at = capture.const('obj', 'foo', 'call', 'at', capture.call);
@@ -341,7 +343,7 @@ t.test('at: returns empty object if #capture() returns an empty stack', t => {
 });
 
 t.test('at: eval', t => {
-  const stackUtil = new StackUtils({internals: internals(), cwd: fixtureDir});
+  const stackUtil = new StackUtils({internals: internals(), cwd: utils.fixtureDir});
   const capture = new CaptureFixture(stackUtil);
 
   const at = capture.eval('call', 'at', capture.call);
@@ -402,7 +404,7 @@ t.test('parseLine', t => {
     evalOrigin: /CaptureFixture.eval|<anonymous>/,
     evalLine: 57,
     evalColumn: 9,
-    evalFile: path.join(fixtureDir, 'capture-fixture.js').replace(/\\/g, '/'),
+    evalFile: path.join(utils.fixtureDir, 'capture-fixture.js').replace(/\\/g, '/'),
     function: 'eval'
   };
 

--- a/test/test.js
+++ b/test/test.js
@@ -99,10 +99,6 @@ StackUtils.natives = [
 const LinuxStack1 = join(linuxStack1(), internalStack());
 const WindowsStack1 = join(windowsStack1(), internalStack());
 
-const version = process.version.slice(1).split('.').map(function (val) {
-  return parseInt(val, 10);
-});
-
 t.test('must be called with new', t => {
   t.is(typeof StackUtils, 'function');
   const stackUtils = StackUtils;
@@ -356,12 +352,6 @@ t.test('at: eval', t => {
     function: 'eval'
   };
 
-  // TODO: There are some inconsistencies between this and how `parseLine` works.
-  if (version[0] < 4) {
-    expected.type = 'CaptureFixture';
-    expected.function = 'eval';
-  }
-
   t.match(at, expected);
   t.end()
 });
@@ -415,10 +405,6 @@ t.test('parseLine', t => {
     evalFile: path.join(fixtureDir, 'capture-fixture.js').replace(/\\/g, '/'),
     function: 'eval'
   };
-
-  if (version[0] < 4) {
-    expected.function = 'CaptureFixture.eval';
-  }
 
   const actual = stack.parseLine(evalStack[2]);
 


### PR DESCRIPTION
Highlights:

* **Breaking** require Node.js 4
* Convert to ES2015, use `standard`
* Bring back Travis and AppVeyor
* Correctly handle symbol functions, e.g. `Symbol.iterator`. See https://github.com/avajs/ava/issues/1269