### PR TITLE
Avoid relying on Node’s internals

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,11 @@ module.exports.nodeInternals = nodeInternals;
 
 function nodeInternals() {
   if (!module.exports.natives) {
-    module.exports.natives = Object.keys(process.binding('natives'));
+    var officialList = require('module').builtinModules;
+    /* istanbul ignore next: only one branch is reachable per run */
+    module.exports.natives = officialList ?
+      Array.from(officialList) :
+      Object.keys(process.binding('natives'));
     module.exports.natives.push('bootstrap_node', 'node',
                                 'internal/bootstrap/node');
   }


### PR DESCRIPTION
`process.binding()` is not a public API, and should
not be used.

Luckily, Node recently introduced an API that does
exactly what stack-utils needs:
https://nodejs.org/api/modules.html#modules_module_builtinmodules

So use that instead and keep the old path as a fallback.