### PR TITLE
Simplify api

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,9 +16,27 @@ natives.push(
 );
 
 class StackUtils {
-  constructor (opts = {}) {
-    this._cwd = (opts.cwd || process.cwd()).replace(/\\/g, '/');
-    this._internals = opts.internals || [];
+  constructor (opts) {
+    opts = {
+      ignoredPackages: [],
+      ...opts
+    };
+
+    if ('internals' in opts === false) {
+      opts.internals = StackUtils.nodeInternals();
+    }
+
+    if ('cwd' in opts === false) {
+      opts.cwd = process.cwd()
+    }
+
+    this._cwd = opts.cwd.replace(/\\/g, '/');
+    this._internals = [].concat(
+      opts.internals,
+      opts.ignoredPackages.length === 0 ? [] :
+        new RegExp(`[\/\\\\]node_modules[\/\\\\](?:${opts.ignoredPackages.join('|')})[\/\\\\][^:]+:\\d+:\\d+`)
+    );
+
     this._wrapCallSite = opts.wrapCallSite || false;
   }
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const escapeStringRegexp = require('escape-string-regexp');
+
 const natives = [].concat(
   require('module').builtinModules,
   'bootstrap_node',
@@ -33,8 +35,7 @@ class StackUtils {
     this._cwd = opts.cwd.replace(/\\/g, '/');
     this._internals = [].concat(
       opts.internals,
-      opts.ignoredPackages.length === 0 ? [] :
-        new RegExp(`[\/\\\\]node_modules[\/\\\\](?:${opts.ignoredPackages.join('|')})[\/\\\\][^:]+:\\d+:\\d+`)
+      ignoredPackagesRegExp(opts.ignoredPackages)
     );
 
     this._wrapCallSite = opts.wrapCallSite || false;
@@ -297,6 +298,16 @@ function setFile (result, filename, cwd) {
 
     result.file = filename;
   }
+}
+
+function ignoredPackagesRegExp(ignoredPackages) {
+  if (ignoredPackages.length === 0) {
+    return [];
+  }
+
+  const packages = ignoredPackages.map(mod => escapeStringRegexp(mod));
+
+  return new RegExp(`[\/\\\\]node_modules[\/\\\\](?:${packages.join('|')})[\/\\\\][^:]+:\\d+:\\d+`)
 }
 
 const re = new RegExp(

--- a/index.js
+++ b/index.js
@@ -328,11 +328,3 @@ const re = new RegExp(
 const methodRe = /^(.*?) \[as (.*?)\]$/;
 
 module.exports = StackUtils;
-
-const bound = new StackUtils();
-
-Object.getOwnPropertyNames(StackUtils.prototype).forEach(key => {
-  if (key !== 'constructor') {
-    StackUtils[key] = bound[key].bind(bound);
-  }
-});

--- a/package-lock.json
+++ b/package-lock.json
@@ -524,6 +524,14 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        }
       }
     },
     "chokidar": {
@@ -866,10 +874,9 @@
       "dev": true
     },
     "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
     },
     "esm": {
       "version": "3.2.25",
@@ -2691,6 +2698,12 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
           "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "ms": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "index.js"
   ],
   "devDependencies": {
+    "arg": "^4.1.2",
     "bluebird": "^3.7.2",
     "coveralls": "^3.0.9",
     "nested-error-stacks": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
   "files": [
     "index.js"
   ],
+  "dependencies": {
+    "escape-string-regexp": "^2.0.0"
+  },
   "devDependencies": {
-    "arg": "^4.1.2",
     "bluebird": "^3.7.2",
     "coveralls": "^3.0.9",
     "nested-error-stacks": "^2.1.0",

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,17 @@ Creates a new `stackUtils` instance.
 Type: `array` of `RegularExpression`s  
 
 A set of regular expressions that match internal stack stack trace lines which should be culled from the stack trace.
-`StackUtils.nodeInternals()` returns a set of relatively sensible defaults for use on the node platform.
+The default is `StackUtils.nodeInternals()`, this can be disabled by setting `[]` or appended using
+`StackUtils.nodeInternals().concat(additionalRegExp)`.  See also `ignoredPackages`.
+
+##### ignoredPackages
+
+Type: `array` of `string`s
+
+An array of npm modules to be culled from the stack trace.  This list will mapped to regular
+expressions and merged with the `internals`.
+
+Default `''`.
 
 ##### cwd
 

--- a/test/node-modules.js
+++ b/test/node-modules.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const t = require('tap');
+const arg = require('arg');
+
+const StackUtils = require('../');
+
+function clean(stack, ...ignoredPackages) {
+  const stackUtil = new StackUtils({ignoredPackages});
+
+  return stackUtil.clean(stack);
+}
+
+try {
+  // This is being used as an easy to test error being thrown by a node_module.
+  arg();
+} catch (e) {
+  t.match(clean(e.stack), 'node_modules/arg/');
+  t.notMatch(clean(e.stack, 'arg'), 'node_modules/arg/');
+  t.match(clean(e.stack, 'resolve-from'), 'node_modules/arg/');
+  t.notMatch(clean(e.stack, 'arg', 'resolve-from'), 'node_modules/arg/');
+  t.notMatch(clean(e.stack, 'resolve-from', 'arg'), 'node_modules/arg/');
+}

--- a/test/test.js
+++ b/test/test.js
@@ -134,12 +134,12 @@ t.test('clean: truncates cwd', t => {
     'startup (node.js:141:18)'
   ]);
 
-  let stack = new StackUtils({cwd: '/user/dev/project'});
+  let stack = new StackUtils({cwd: '/user/dev/project', internals: []});
   t.is(stack.clean(LinuxStack1), expected, 'accepts a linux string');
   t.is(stack.clean(LinuxStack1.split('\n')), expected, 'accepts an array');
   t.is(stack.clean(LinuxStack1.split('\n').slice(1)), expected, 'slices off the message line');
 
-  stack = new StackUtils({cwd: 'Z:\\user\\dev\\project'});
+  stack = new StackUtils({cwd: 'Z:\\user\\dev\\project', internals: []});
   t.is(stack.clean(WindowsStack1), expected, 'accepts a windows string');
   t.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -6,99 +6,6 @@ const StackUtils = require('../');
 const CaptureFixture = require('./fixtures/capture-fixture');
 const utils = require('./_utils');
 
-// Use a fixed known set of native modules, since this changes
-// depending on the version of Node we're testing with.
-StackUtils.natives = [
-  'internal/bootstrap_node',
-  '_debug_agent',
-  '_debugger',
-  'assert',
-  'async_hooks',
-  'buffer',
-  'child_process',
-  'console',
-  'constants',
-  'crypto',
-  'cluster',
-  'dgram',
-  'dns',
-  'domain',
-  'events',
-  'fs',
-  'http',
-  '_http_agent',
-  '_http_client',
-  '_http_common',
-  '_http_incoming',
-  '_http_outgoing',
-  '_http_server',
-  'https',
-  '_linklist',
-  'module',
-  'net',
-  'os',
-  'path',
-  'process',
-  'punycode',
-  'querystring',
-  'readline',
-  'repl',
-  'stream',
-  '_stream_readable',
-  '_stream_writable',
-  '_stream_duplex',
-  '_stream_transform',
-  '_stream_passthrough',
-  '_stream_wrap',
-  'string_decoder',
-  'sys',
-  'timers',
-  'tls',
-  '_tls_common',
-  '_tls_legacy',
-  '_tls_wrap',
-  'tty',
-  'url',
-  'util',
-  'v8',
-  'vm',
-  'zlib',
-  'internal/buffer',
-  'internal/child_process',
-  'internal/cluster',
-  'internal/freelist',
-  'internal/fs',
-  'internal/linkedlist',
-  'internal/net',
-  'internal/module',
-  'internal/process/next_tick',
-  'internal/process/promises',
-  'internal/process/stdio',
-  'internal/process/warning',
-  'internal/process',
-  'internal/readline',
-  'internal/repl',
-  'internal/socket_list',
-  'internal/url',
-  'internal/util',
-  'internal/v8_prof_polyfill',
-  'internal/v8_prof_processor',
-  'internal/streams/lazy_transform',
-  'internal/streams/BufferList',
-  'v8/tools/splaytree',
-  'v8/tools/codemap',
-  'v8/tools/consarray',
-  'v8/tools/csvparser',
-  'v8/tools/profile',
-  'v8/tools/profile_view',
-  'v8/tools/logreader',
-  'v8/tools/tickprocessor',
-  'v8/tools/SourceMap',
-  'v8/tools/tickprocessor-driver',
-  'bootstrap_node',
-  'node'
-];
-
 const LinuxStack1 = utils.join(linuxStack1(), internalStack());
 const WindowsStack1 = utils.join(windowsStack1(), internalStack());
 
@@ -145,7 +52,7 @@ t.test('clean: truncates cwd', t => {
 });
 
 t.test('clean: eliminates internals', t => {
-  let stack = new StackUtils({cwd: '/user/dev', internals: StackUtils.nodeInternals()});
+  let stack = new StackUtils({cwd: '/user/dev'});
   const expected = utils.join([
     'foo (project/foo.js:3:8)',
     'bar (project/foo.js:7:2)',
@@ -154,13 +61,13 @@ t.test('clean: eliminates internals', t => {
   ]);
   t.is(stack.clean(LinuxStack1), expected);
 
-  stack = new StackUtils({cwd: 'Z:\\user\\dev', internals: StackUtils.nodeInternals()});
+  stack = new StackUtils({cwd: 'Z:\\user\\dev'});
   t.is(stack.clean(WindowsStack1), expected);
   t.end();
 });
 
 t.test('clean: returns null if it is all internals', t => {
-  const stack = new StackUtils({internals: StackUtils.nodeInternals()});
+  const stack = new StackUtils();
   t.is(stack.clean(utils.join(internalStack())), '');
   t.end();
 });
@@ -438,7 +345,8 @@ t.test('parseLine', t => {
 });
 
 t.test('parseLine: handles native errors', t => {
-  t.same(StackUtils.parseLine('    at Error (native)'), {
+  const stackUtils = new StackUtils();
+  t.same(stackUtils.parseLine('    at Error (native)'), {
     native: true,
     function: 'Error'
   });
@@ -447,7 +355,8 @@ t.test('parseLine: handles native errors', t => {
 
 t.test('parseLine: handles parens', t => {
   const line = '    at X.<anonymous> (/USER/Db (Person)/x/y.js:14:11)';
-  t.same(StackUtils.parseLine(line), {
+  const stackUtils = new StackUtils();
+  t.same(stackUtils.parseLine(line), {
     line: 14,
     column: 11,
     file: '/USER/Db (Person)/x/y.js',


### PR DESCRIPTION
* Add `ignoredPackages` option, populate `internals` by default.
* Remove bound singleton, export StackUtils class only

Fixes #15