### PR TITLE
fix: Fix to be compat with the JS override mistake

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ class StackUtils {
     setFile(res, site.getFileName(), this._cwd);
 
     if (site.isConstructor()) {
-      res.constructor = true;
+      Object.defineProperty(res, 'constructor', { value: true });
     }
 
     if (site.isEval()) {
@@ -260,7 +260,7 @@ class StackUtils {
     setFile(res, file, this._cwd);
 
     if (ctor) {
-      res.constructor = true;
+      Object.defineProperty(res, 'constructor', { value: true });
     }
 
     if (evalOrigin) {

--- a/index.js
+++ b/index.js
@@ -161,7 +161,10 @@ class StackUtils {
     setFile(res, site.getFileName(), this._cwd);
 
     if (site.isConstructor()) {
-      Object.defineProperty(res, 'constructor', { value: true });
+      Object.defineProperty(res, 'constructor', {
+        value: true,
+        configurable: true,
+      });
     }
 
     if (site.isEval()) {
@@ -260,7 +263,10 @@ class StackUtils {
     setFile(res, file, this._cwd);
 
     if (ctor) {
-      Object.defineProperty(res, 'constructor', { value: true });
+      Object.defineProperty(res, 'constructor', {
+        value: true,
+        configurable: true,
+      });
     }
 
     if (evalOrigin) {


### PR DESCRIPTION
JavaScript has a misfeature often called the "override mistake". In an assignment such as
```js
res.constructor = true;
```
if `res` does not yet have its own `constructor` property, but inherits one that this assignment would override (as is the intention here), but the property that would be overridden is a non-writable data property, then the assignment fails. Hardened JS and similar frameworks for securing JS routinely freeze all the primordial objects, which causes their data properties to become non-configurable, non-writable. Also, the TC53 JS standard for embedded devices standardizes on Hardened JS, which will also cause this problem. The XS JS engine for embedded devices use the Hardened JS configuration by default on embedded devices.

Object literals and classes override inherited properties without problem because they use JS's "define" semantics rather than JS's peculiar "assign" semantics. You can also do so manually via `Object.defineProperty`, as this PR does to repair this issue.

See also
https://github.com/tapjs/stack-utils/issues/70
https://github.com/Agoric/agoric-sdk/pull/6451